### PR TITLE
Enlarge the range of convert double to string

### DIFF
--- a/src/stdio/printf.c
+++ b/src/stdio/printf.c
@@ -305,12 +305,11 @@ static size_t _ftoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, d
     prec = 6U;
   }
   // limit precision to 9, cause a prec >= 10 can lead to overflow errors
-  while ((len < PRINTF_FTOA_BUFFER_SIZE) && (prec > 9U)) {
-    buf[len++] = '0';
-    prec--;
+  if (prec > 9U) {
+    prec = 9;
   }
 
-  long long whole = (long long)value;
+  unsigned long long whole = (unsigned long long)value;
   double tmp = (value - whole) * pow10[prec];
   unsigned long frac = (unsigned long)tmp;
   diff = tmp - frac;

--- a/src/stdio/printf.c
+++ b/src/stdio/printf.c
@@ -288,7 +288,7 @@ static size_t _ftoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, d
   double diff = 0.0;
 
   // if input is larger than thres_max, revert to exponential
-  const double thres_max = (double)0x7FFFFFFF;
+  const double thres_max = (double)0x7FFFFFFFFFFFFFFF;
 
   // powers of 10
   static const double pow10[] = { 1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000 };
@@ -310,7 +310,7 @@ static size_t _ftoa(out_fct_type out, char* buffer, size_t idx, size_t maxlen, d
     prec--;
   }
 
-  int whole = (int)value;
+  long long whole = (long long)value;
   double tmp = (value - whole) * pow10[prec];
   unsigned long frac = (unsigned long)tmp;
   diff = tmp - frac;


### PR DESCRIPTION
Enlarge the range of convert double to string, now any value larger than `0x7FFFFFFF` will be empty, a simple way is to enlarge the range.